### PR TITLE
SS-35 | No-show candidate to be regretted and removed from Talent pool

### DIFF
--- a/app/Http/Controllers/InterviewController.php
+++ b/app/Http/Controllers/InterviewController.php
@@ -531,9 +531,26 @@ class InterviewController extends Controller
                 'status' => 'No Show'
             ]);
 
-            //Increment No Show
-            $interview->applicant->increment('no_show');
-            
+            // Increment No Show for the applicant
+            $applicant = $interview->applicant;
+
+            if ($applicant) {
+                $applicant->increment('no_show');
+
+                // Check if the 'no_show' count is >= 2
+                if ($applicant->no_show >= 2) {
+                    // Create Notification for No Show
+                    $notification = new Notification();
+                    $notification->user_id = $applicant->id;
+                    $notification->causer_id = $userID;
+                    $notification->subject()->associate($interview); // Associate notification with the interview or application
+                    $notification->type_id = 1;
+                    $notification->notification = "No-show count has reached " . $applicant->no_show . " 🚫";
+                    $notification->read = "No";
+                    $notification->save();
+                }
+            }
+
             return response()->json([
                 'success' => true,
                 'interview' => $interview,

--- a/app/Http/Controllers/InterviewController.php
+++ b/app/Http/Controllers/InterviewController.php
@@ -530,6 +530,9 @@ class InterviewController extends Controller
             $interview->update([
                 'status' => 'No Show'
             ]);
+
+            //Increment No Show
+            $interview->applicant->increment('no_show');
             
             return response()->json([
                 'success' => true,


### PR DESCRIPTION
This PR updates the process for handling no-show candidates by marking them as 'No Show', creating a notification, and incrementing their no-show count. If the no-show count reaches 2, the candidate is automatically regretted and removed from the Talent pool.