### PR TITLE
SS-58 | Update VacancyController and Validation Logic for RPP, DTDP, and DPP Roles

### DIFF
--- a/app/Http/Controllers/ApplicantProfileController.php
+++ b/app/Http/Controllers/ApplicantProfileController.php
@@ -398,23 +398,23 @@ class ApplicantProfileController extends Controller
                 // Update the applicant's state
                 $applicant->update(['state_id' => $scheduledStateId]);
             }
-    
+
             // Prepare a WhatsApp message
             $whatsappMessage = "You have a request to reschedule your interview to " .
                 Carbon::parse($existingInterview->reschedule_date)->format('d M Y \a\t H:i') .
                 ". Would you like to view the details?";
-    
+
             // Define the message type and template
             $type = 'template';
             $template = 'interview_reschedule_view';
-    
+
             // Prepare the variables for the WhatsApp template
             $variables = [
                 $applicant->firstname ?: 'N/A',  // Applicant's first name
                 Carbon::parse($existingInterview->reschedule_date)->format('d M Y') ?: 'N/A', // Rescheduled date
                 Carbon::parse($existingInterview->reschedule_date)->format('H:i') ?: 'N/A', // Rescheduled time
             ];
-    
+
             // Dispatch WhatsApp message
             SendWhatsAppMessage::dispatch($applicant, $whatsappMessage, $type, $template, $variables);
 

--- a/app/Http/Controllers/ApplicationController.php
+++ b/app/Http/Controllers/ApplicationController.php
@@ -159,7 +159,7 @@ class ApplicationController extends Controller
             'education_id' => ['required', 'integer', 'exists:educations,id'],
             'duration_id' => ['required', 'integer', 'exists:durations,id'],
             'public_holidays' => ['required', 'in:Yes,No', function ($attribute, $value, $fail) {
-            if ($value !== 'Yes') {
+                if ($value !== 'Yes') {
                     $fail('You will not be eligible for a position unless you elect "Yes" for public holidays.');
                 }
             }],
@@ -422,7 +422,7 @@ class ApplicationController extends Controller
             'public_holidays' => ['required', 'in:Yes,No', function ($attribute, $value, $fail) {
                 if ($value !== 'Yes') {
                     $fail('You will not be eligible for a position unless you elect "Yes" for public holidays.');
-                    }
+                }
             }],
             'environment' => ['required', 'in:Yes,No', function ($attribute, $value, $fail) {
                 if ($value !== 'Yes') {

--- a/app/Http/Controllers/DPPController.php
+++ b/app/Http/Controllers/DPPController.php
@@ -534,6 +534,8 @@ class DPPController extends Controller
                  'percentMovementAppointedPerMonth' => $percentMovementAppointedPerMonth,
                  'percentMovementRejectedPerMonth' => $percentMovementRejectedPerMonth,
                  'adoptionRate' => $adoptionRate,
+                 'divisionWideAveragetimeToShortlist' => $divisionWideAveragetimeToShortlist,
+                 'divisionWideTimeToHire' => $divisionWideTimeToHire
              ]);
         }
          return view('404');

--- a/app/Http/Controllers/InterviewController.php
+++ b/app/Http/Controllers/InterviewController.php
@@ -70,7 +70,7 @@ class InterviewController extends Controller
                 return $query->where('interviewer_id', $userID);
             })
             ->orderBy('scheduled_date', 'desc')
-            ->orderBy('updated_at', 'desc') 
+            ->orderBy('updated_at', 'desc')
             ->get();
 
             return view('interviews', [
@@ -179,7 +179,7 @@ class InterviewController extends Controller
             ]);
         } catch (\Exception $e) {
             // An error occurred; cancel the transaction
-            DB::rollBack();  
+            DB::rollBack();
 
             // Return an error response
             return response()->json([
@@ -254,23 +254,23 @@ class InterviewController extends Controller
                 // Update the applicant's state
                 $applicant->update(['state_id' => $scheduledStateId]);
             }
-    
+
             // Prepare a WhatsApp message
             $whatsappMessage = "You have a request to reschedule your interview to " .
                 Carbon::parse($existingInterview->reschedule_date)->format('d M Y \a\t H:i') .
                 ". Would you like to view the details?";
-    
+
             // Define the message type and template
             $type = 'template';
             $template = 'interview_reschedule_view';
-    
+
             // Prepare the variables for the WhatsApp template
             $variables = [
                 $applicant->firstname ?: 'N/A',  // Applicant's first name
                 Carbon::parse($existingInterview->reschedule_date)->format('d M Y') ?: 'N/A', // Rescheduled date
                 Carbon::parse($existingInterview->reschedule_date)->format('H:i') ?: 'N/A', // Rescheduled time
             ];
-    
+
             // Dispatch WhatsApp message
             SendWhatsAppMessage::dispatch($applicant, $whatsappMessage, $type, $template, $variables);
 
@@ -436,7 +436,7 @@ class InterviewController extends Controller
                 // Dispatch a job to send the WhatsApp message
                 SendWhatsAppMessage::dispatch($applicant, $whatsappMessage, $type, $template, $variables);
             // Additional check if the interview exists, the user is the applicant, and the status is 'Reschedule'.
-            } else if ($interview && $interview->applicant_id == $user->applicant_id && $interview->status == 'Reschedule'  && $interview->reschedule_by == 'Manager') {
+            } elseif ($interview && $interview->applicant_id == $user->applicant_id && $interview->status == 'Reschedule'  && $interview->reschedule_by == 'Manager') {
                 // Parse the reschedule_date
                 $rescheduleDateTime = new \Carbon\Carbon($interview->reschedule_date);
 
@@ -470,7 +470,7 @@ class InterviewController extends Controller
                     $notification->save();
                 }
             // Additional check if the current user is the applicant, and confirm the interview in that case
-            } else if ($interview && $interview->applicant_id == $user->applicant_id && $interview->status == 'Manager') {
+            } elseif ($interview && $interview->applicant_id == $user->applicant_id && $interview->status == 'Manager') {
                 //Interview Update
                 $interview->update([
                     'status' => 'Confirmed'
@@ -719,7 +719,7 @@ class InterviewController extends Controller
 
                 // Prepare a WhatsApp message
                 $whatsappMessage = "You have a request to reschedule your interview to " .
-                    $interview->reschedule_date->format('d M Y \a\t H:i') . 
+                    $interview->reschedule_date->format('d M Y \a\t H:i') .
                     ". Would you like to view the details?";
 
                 // Define the message type
@@ -959,16 +959,16 @@ class InterviewController extends Controller
                     optional($vacancy->store->town)->name ?: 'N/A',  // If $vacancy->store->town or its name is null, use 'N/A'
                     optional($interview->scheduled_date)->format('d M Y') ?: 'N/A', // Interview date
                     optional($interview->start_time)->format('H:i') ?: 'N/A' // Interview start time
-                ];                  
+                ];
 
                 // Dispatch a job to send the WhatsApp message
                 SendWhatsAppMessage::dispatch($applicant, $whatsappMessage, $type, $template, $variables);
 
-            return response()->json([
+                return response()->json([
                 'success' => true,
                 'interview' => $interview,
                 'message' => 'Interview cancelled!',
-            ], 201);
+                ], 201);
         } catch (\Illuminate\Validation\ValidationException $e) {
             // Handle validation failure
             return response()->json([

--- a/app/Http/Controllers/ShortlistController.php
+++ b/app/Http/Controllers/ShortlistController.php
@@ -259,7 +259,7 @@ class ShortlistController extends Controller
                 $query->whereNull('user_delete')   // Include where user_delete is NULL
                       ->orWhere('user_delete', 'No'); // Or where user_delete equals 'No'
             })
-            ->where('state_id', '>=', $completeStateID)            
+            ->where('state_id', '>=', $completeStateID)
             ->whereHas('brands', function ($query) use ($vacancyBrandID) {
                 // Check if the applicant has the vacancyBrandID in their brands or brand_id = 1
                 $query->where('brand_id', 1);

--- a/app/Jobs/SendIdNumberToSap.php
+++ b/app/Jobs/SendIdNumberToSap.php
@@ -13,7 +13,10 @@ use GuzzleHttp\Client as GuzzleClient;
 
 class SendIdNumberToSap implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
 
     protected $idNumber;
     protected $applicant;

--- a/app/Models/Store.php
+++ b/app/Models/Store.php
@@ -53,6 +53,12 @@ class Store extends Model
         return $this->belongsTo(Division::class);
     }
 
+    //Users
+    public function users()
+    {
+        return $this->hasMany(User::class);
+    }
+
     /**
      * The attributes that should be logged.
      * @var bool

--- a/app/Providers/TopbarServiceProvider.php
+++ b/app/Providers/TopbarServiceProvider.php
@@ -49,7 +49,7 @@ class TopbarServiceProvider extends ServiceProvider
             ->where('show', 'Yes')
             ->orderBy('created_at', 'desc')
             ->get()
-            ->groupBy(function($notification) {
+            ->groupBy(function ($notification) {
                 return $notification->subject_type . ':' . $notification->subject_id;
             })
             ->map(function ($groupedNotifications) {

--- a/app/Services/ChatService.php
+++ b/app/Services/ChatService.php
@@ -2464,30 +2464,30 @@ class ChatService
                         "Position Name" => $latestInterview->vacancy->position->name ?? 'N/A', // If no position, set 'N/A'
                         "Store Name" => ($latestInterview->vacancy->store->brand->name ?? '') . ' (' . ($latestInterview->vacancy->store->town->name ?? 'N/A') . ')', // Brand and town or default 'Our Office'
                         "Interview Location" => $latestInterview->location ?? 'N/A', // Interview location or 'N/A'
-                        
+
                         // Check if scheduled_date is an instance of Carbon or try parsing the date string
                         "Interview Date" => $latestInterview->scheduled_date instanceof Carbon
                                             ? $latestInterview->scheduled_date->format('d M Y')
                                             : (strtotime($latestInterview->scheduled_date) ? date('d M Y', strtotime($latestInterview->scheduled_date)) : 'N/A'), // Fallback to strtotime if not Carbon
-                        
+
                         // Check if start_time is an instance of Carbon or try parsing the time string
                         "Interview Time" => $latestInterview->start_time instanceof Carbon
                                             ? $latestInterview->start_time->format('H:i')
                                             : (strtotime($latestInterview->start_time) ? date('H:i', strtotime($latestInterview->start_time)) : 'N/A'), // Fallback to strtotime if not Carbon
-                    
+
                         // Check if reschedule_date is an instance of Carbon or try parsing the date string
                         "Reschedule Date" => $latestInterview->reschedule_date instanceof Carbon
                                             ? $latestInterview->reschedule_date->format('d M Y')
                                             : (strtotime($latestInterview->reschedule_date) ? date('d M Y', strtotime($latestInterview->reschedule_date)) : 'N/A'), // Fallback to strtotime if not Carbon
-                    
+
                         // Check if reschedule_date is an instance of Carbon or try parsing the time string
                         "Reschedule Time" => $latestInterview->reschedule_date instanceof Carbon
                                             ? $latestInterview->reschedule_date->format('H:i')
                                             : (strtotime($latestInterview->reschedule_date) ? date('H:i', strtotime($latestInterview->reschedule_date)) : 'N/A'), // Fallback to strtotime if not Carbon
-                    
+
                         "Notes" => $latestInterview->notes ?? 'N/A', // Additional notes or 'N/A'
                         "Status" => $latestInterview->status ?? 'N/A' // Interview status
-                    ];                                       
+                    ];
 
                     // Check if interview status is "Reschedule"
                     if ($latestInterview->status === "Reschedule") {
@@ -2509,14 +2509,14 @@ class ChatService
 
                             // Send the updated messages and log the outgoing messages.
                             $this->sendAndLogMessages($applicant, $messages, $client, $to, $from, $token);
-                    
+
                             // Update the applicant's state to 'complete'.
                             $stateID = State::where('code', 'complete')->value('id');
                             $applicant->update(['state_id' => $stateID]);
                         } elseif ($latestInterview->reschedule_by === "Manager") {
                             // Fetch the messages associated with the 'reschedule_manager' state.
                             $messages = $this->fetchStateMessages('reschedule_manager');
-                    
+
                             // Loop through each message and replace placeholders with the corresponding applicant/interview data.
                             foreach ($messages as &$message) {
                                 foreach ($dataToReplace as $key => $value) {
@@ -2531,7 +2531,7 @@ class ChatService
 
                             // Send the updated messages and log the outgoing messages.
                             $this->sendAndLogMessages($applicant, $messages, $client, $to, $from, $token);
-                    
+
                             // Update the applicant's state to 'schedule'.
                             $stateID = State::where('code', 'schedule')->value('id');
                             $applicant->update(['state_id' => $stateID]);
@@ -2539,7 +2539,7 @@ class ChatService
                     } else {
                         // Handle the regular scheduled interview case
                         $messages = $this->fetchStateMessages('schedule');
-                    
+
                         // Loop through each message and replace placeholders with the corresponding applicant/interview data.
                         foreach ($messages as &$message) {
                             foreach ($dataToReplace as $key => $value) {
@@ -2554,7 +2554,7 @@ class ChatService
 
                         // Send the updated messages and log the outgoing messages.
                         $this->sendAndLogMessages($applicant, $messages, $client, $to, $from, $token);
-                    
+
                         // Update the applicant's state to 'schedule'.
                         $stateID = State::where('code', 'schedule')->value('id');
                         $applicant->update(['state_id' => $stateID]);
@@ -2738,7 +2738,7 @@ class ChatService
                     $scheduledDate = $latestInterview->scheduled_date->format('d M Y'); // Format the current scheduled date
                     // Add 1 day to the scheduled date using Carbon
                     $suggestedDateTime = Carbon::parse($latestInterview->scheduled_date)->addDay();
-                    $suggestedDate = $suggestedDateTime->format('d M Y'); 
+                    $suggestedDate = $suggestedDateTime->format('d M Y');
 
                     // Send a message prompting the applicant to suggest a new date and time.
                     $messages = [

--- a/app/Services/GoogleMapsService.php
+++ b/app/Services/GoogleMapsService.php
@@ -26,7 +26,7 @@ class GoogleMapsService
 
     /**
      * Geocode an address by sending a request to Google Maps Geocoding API.
-     * 
+     *
      * @param string $address The address to geocode.
      * @return array|null The geocoded result or null if the request fails.
      */
@@ -38,7 +38,7 @@ class GoogleMapsService
 
     /**
      * Get the current HTTP client instance.
-     * 
+     *
      * @return \GuzzleHttp\Client
      */
     public function getClient()
@@ -48,7 +48,7 @@ class GoogleMapsService
 
     /**
      * Set a custom HTTP client instance.
-     * 
+     *
      * @param \GuzzleHttp\Client $client The HTTP client to set.
      */
     public function setClient(Client $client)
@@ -59,7 +59,7 @@ class GoogleMapsService
     /**
      * Reverse geocode coordinates (latitude and longitude) by sending a request
      * to Google Maps Geocoding API.
-     * 
+     *
      * @param float $latitude The latitude coordinate.
      * @param float $longitude The longitude coordinate.
      * @return array|null The reverse geocoded result or null if the request fails.
@@ -72,7 +72,7 @@ class GoogleMapsService
 
     /**
      * Send a request to the Google Maps API and process the response.
-     * 
+     *
      * @param string $endpoint The API endpoint (e.g., 'geocode/json').
      * @param array $parameters The parameters to send with the request.
      * @return array|null The processed geocoded data or null if the request fails.
@@ -160,7 +160,6 @@ class GoogleMapsService
             // Log a warning if the geocoding request failed
             Log::warning('Geocoding API returned status: ' . $data['status']);
             return null;
-
         } catch (\Exception $e) {
             // Log the error message for debugging
             Log::error('Geocoding API error: ' . $e->getMessage());
@@ -171,7 +170,7 @@ class GoogleMapsService
     /**
      * Determine which province the given coordinates fall into by checking
      * against predefined provincial boundaries.
-     * 
+     *
      * @param float $latitude The latitude of the coordinates.
      * @param float $longitude The longitude of the coordinates.
      * @return int|null The ID of the province in the database or null if not found.

--- a/resources/views/dtdp/home.blade.php
+++ b/resources/views/dtdp/home.blade.php
@@ -147,7 +147,7 @@
                                         Time to Shortlist
                                     </p>
                                     @php
-                                        $totalDays = $divisionWideAveragetimeToShortlist;
+                                        $totalDays = 0;
                                         $totalMinutes = $totalDays * 24 * 60; // Convert days to minutes
                                         $interval = \Carbon\CarbonInterval::minutes($totalMinutes);
                                         $formattedInterval = $interval->cascade()->format('%dD %hH %iM');

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -60,15 +60,15 @@
                 <li class="menu-title"><span>@lang('translation.menu')</span></li>
                 <li class="nav-item">
                     <a class="nav-link menu-link" href="{{ url($url.'home') }}">
-                        <i class="ri-home-3-line"></i> 
+                        <i class="ri-home-3-line"></i>
                         <span>Home</span>
                     </a>
-                </li>                
+                </li>
                 @if ($user->role_id > 6)
                     @if ($user->applicant)
                         <li class="nav-item">
                             <a class="nav-link menu-link" href="{{ route('interviews.index') }}">
-                                <i class="ri-briefcase-line"></i> 
+                                <i class="ri-briefcase-line"></i>
                                 <span>My Interviews</span>
                             </a>
                         </li>
@@ -77,7 +77,7 @@
                 @if ($user->role_id <= 6)
                     <li class="nav-item">
                         <a class="nav-link menu-link" href="#sidebarVacancies" data-bs-toggle="collapse" role="button" aria-expanded="false" aria-controls="sidebarVacancies">
-                            <i class="ri-briefcase-line"></i> 
+                            <i class="ri-briefcase-line"></i>
                             <span>Vacancies</span>
                         </a>
                         <div class="collapse menu-dropdown" id="sidebarVacancies">
@@ -97,19 +97,19 @@
                     </li>
                     <li class="nav-item">
                         <a class="nav-link menu-link" href="{{ route('shortlist.index') }}">
-                            <i class="ri-list-check-2"></i> 
+                            <i class="ri-list-check-2"></i>
                             <span>My Shortlists</span>
                         </a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link menu-link" href="{{ route('interviews.index') }}">
-                            <i class="ri-briefcase-line"></i> 
+                            <i class="ri-briefcase-line"></i>
                             <span>My Interviews</span>
                         </a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link menu-link" href="{{ route('applicants.index') }}">
-                            <i class="ri-profile-line"></i> 
+                            <i class="ri-profile-line"></i>
                             <span>Saved Applicants</span>
                         </a>
                     </li>
@@ -117,7 +117,7 @@
                 @if ($user->role_id <= 2)
                     <li class="nav-item">
                         <a class="nav-link menu-link" href="#sidebarApprovals" data-bs-toggle="collapse" role="button" aria-expanded="false" aria-controls="sidebarApprovals">
-                            <i class="ri-shield-check-line"></i> 
+                            <i class="ri-shield-check-line"></i>
                             <span>Approvals</span>
                         </a>
                         <div class="collapse menu-dropdown" id="sidebarApprovals">
@@ -136,11 +136,11 @@
                         </div>
                     </li>
                     <a class="nav-link menu-link" href="#sidebarTemplates" data-bs-toggle="collapse" role="button" aria-expanded="false" aria-controls="sidebarTemplates">
-                        <i class="ri-slideshow-line"></i> 
+                        <i class="ri-slideshow-line"></i>
                         <span>Templates</span>
                     </a>
                     <div class="collapse menu-dropdown" id="sidebarTemplates">
-                        <ul class="nav nav-sm flex-column">                            
+                        <ul class="nav nav-sm flex-column">
                             <li class="nav-item">
                                 <a class="nav-link" href="{{ route('email.index') }}">
                                     Email
@@ -165,7 +165,7 @@
                     </div>
                     <li class="nav-item">
                         <a class="nav-link menu-link" href="#sidebarAssessments" data-bs-toggle="collapse" role="button" aria-expanded="false" aria-controls="sidebarAssessments">
-                            <i class="ri-survey-line"></i> 
+                            <i class="ri-survey-line"></i>
                             <span>Assessments</span>
                         </a>
                         <div class="collapse menu-dropdown" id="sidebarAssessments">
@@ -185,12 +185,12 @@
                     </li>
                     <li class="nav-item">
                         <a class="nav-link menu-link" href="{{ route('weighting.index') }}">
-                            <i class="ri-medal-line"></i> 
+                            <i class="ri-medal-line"></i>
                             <span>Weightings</span>
                         </a>
                     </li>
                     <a class="nav-link menu-link" href="#sidebarUsers" data-bs-toggle="collapse" role="button" aria-expanded="false" aria-controls="sidebarUsers">
-                        <i class="ri-group-line"></i> 
+                        <i class="ri-group-line"></i>
                         <span>Users</span>
                     </a>
                     <div class="collapse menu-dropdown" id="sidebarUsers">
@@ -221,7 +221,7 @@
                     </div>
                     <li class="nav-item">
                         <a class="nav-link menu-link" href="#sidebarJobs" data-bs-toggle="collapse" role="button" aria-expanded="false" aria-controls="sidebarJobs">
-                            <i class="ri-briefcase-3-line"></i> 
+                            <i class="ri-briefcase-3-line"></i>
                             <span>Jobs</span>
                         </a>
                         <div class="collapse menu-dropdown" id="sidebarJobs">
@@ -270,13 +270,13 @@
                                     <a class="nav-link" href="{{ route('hours.index') }}">
                                         Working Hours
                                     </a>
-                                </li>                                
+                                </li>
                             </ul>
                         </div>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link menu-link" href="#sidebarSettings" data-bs-toggle="collapse" role="button" aria-expanded="false" aria-controls="sidebarSettings">
-                            <i class="ri-settings-5-line"></i> 
+                            <i class="ri-settings-5-line"></i>
                             <span>Settings</span>
                         </a>
                         <div class="collapse menu-dropdown" id="sidebarSettings">
@@ -300,7 +300,7 @@
                                     <a class="nav-link" href="{{ route('durations.index') }}">
                                         Experience
                                     </a>
-                                </li>                                
+                                </li>
                                 <li class="nav-item">
                                     <a class="nav-link" href="{{ route('genders.index') }}">
                                         Genders
@@ -330,14 +330,14 @@
                                     <a class="nav-link" href="{{ route('towns.index') }}">
                                         Towns
                                     </a>
-                                </li>                                
+                                </li>
                             </ul>
                         </div>
                     </li>
                     @if ($user->role_id == 1)
                         <li class="nav-item">
                             <a class="nav-link menu-link" href="{{ url('/telescope') }}">
-                                <i class="ri-microscope-line"></i> 
+                                <i class="ri-microscope-line"></i>
                                 <span>Telescope</span>
                             </a>
                         </li>

--- a/resources/views/layouts/topbar.blade.php
+++ b/resources/views/layouts/topbar.blade.php
@@ -127,8 +127,8 @@
                                                                     <p class="mb-1">
                                                                         {{ $notification->notification }} on
                                                                         <a href="{{ route('job-overview.index', ['id' => Crypt::encryptString(optional($notification->subject)->vacancy->id)]) }}">
-                                                                            <b class="text-{{ optional($notification->subject)->vacancy->position->color ?? 'primary'; }}">
-                                                                                {{ optional($notification->subject)->vacancy->position->name ?? 'N/A'; }}
+                                                                            <b class="text-{{ optional($notification->subject)->vacancy->position->color ?? 'primary' }}">
+                                                                                {{ optional($notification->subject)->vacancy->position->name ?? 'N/A' }}
                                                                             </b>
                                                                         </a>
                                                                     </p>
@@ -300,10 +300,10 @@
                                                                 @if ($notification->subject)
                                                                     <div class="fs-13 text-muted">
                                                                         <p class="mb-1">
-                                                                            {{ optional($notification->subject->vacancy)->store->brand->name ?? 'N/A'; }} ({{ optional($notification->subject->vacancy)->store->town->name ?? 'N/A'; }}) for
+                                                                            {{ optional($notification->subject->vacancy)->store->brand->name ?? 'N/A' }} ({{ optional($notification->subject->vacancy)->store->town->name ?? 'N/A' }}) for
                                                                             <a href="{{ route('job-overview.index', ['id' => Crypt::encryptString(optional($notification->subject)->vacancy->id)]) }}">
-                                                                                <b class="text-{{ optional($notification->subject)->vacancy->position->color ?? 'primary'; }}">
-                                                                                    {{ optional($notification->subject)->vacancy->position->name ?? 'N/A'; }}
+                                                                                <b class="text-{{ optional($notification->subject)->vacancy->position->color ?? 'primary' }}">
+                                                                                    {{ optional($notification->subject)->vacancy->position->name ?? 'N/A' }}
                                                                                 </b>
                                                                             </a> on
                                                                             @php
@@ -325,7 +325,7 @@
                                                                             @if ($notification->subject->status == "Scheduled")
                                                                                 <button type="button" data-bs-interview="{{ Crypt::encryptString(optional($notification->subject)->id) }}" class="btn btn-sm rounded-pill btn-success waves-effect waves-light interviewConfirm">
                                                                                     Confirm
-                                                                                </button>                                                                                
+                                                                                </button>
                                                                                 <button type="button" data-bs-interview="{{ Crypt::encryptString(optional($notification->subject)->id) }}" class="btn btn-sm rounded-pill btn-danger waves-effect waves-light interviewDecline">
                                                                                     Decline
                                                                                 </button>
@@ -716,8 +716,8 @@
                                                                 <p class="mb-1">
                                                                     {{ $alert->notification }} on
                                                                     <a href="{{ route('job-overview.index', ['id' => Crypt::encryptString(optional($alert->subject)->vacancy->id)]) }}">
-                                                                        <b class="text-{{ optional($alert->subject)->vacancy->position->color ?? 'primary'; }}">
-                                                                            {{ optional($alert->subject)->vacancy->position->name ?? 'N/A'; }}
+                                                                        <b class="text-{{ optional($alert->subject)->vacancy->position->color ?? 'primary' }}">
+                                                                            {{ optional($alert->subject)->vacancy->position->name ?? 'N/A' }}
                                                                         </b>
                                                                     </a>
                                                                 </p>
@@ -824,7 +824,7 @@
                                                         </div>
                                                     </div>
                                                 </div>
-                                            @endif                                        
+                                            @endif
                                         @endif
                                     @endforeach
                                 </div>

--- a/resources/views/manager/vacancy.blade.php
+++ b/resources/views/manager/vacancy.blade.php
@@ -29,7 +29,7 @@
             <div class="card">
                 <div class="card-header">
                     <h4 class="card-title mb-0">
-                        {{ $vacancy ? 'Update' : 'Post' }} Your Vacancy: 
+                        {{ $vacancy ? 'Update' : 'Post' }} Your Vacancy:
                         {{ $store && $store->brand ? $store->brand->name.' '.$store->name : '' }}
                     </h4>
                 </div><!-- end card header -->
@@ -106,11 +106,11 @@
                             <div class="col-lg-9">
                                 <div class="px-lg-4">
                                     <div class="tab-content">
-                            
+
                                         <!-------------------------------------------------------------------------------------
                                             Position
                                         -------------------------------------------------------------------------------------->
-                            
+
                                         <div class="tab-pane fade show active" id="v-pills-position" role="tabpanel"
                                             aria-labelledby="v-pills-position-tab">
                                             <div>
@@ -119,7 +119,7 @@
                                                     Choose the job position that best matches the vacancy you're looking for.
                                                 </p>
                                             </div>
-                            
+
                                             <div>
                                                 <div class="row gy-3">
                                                     <div class="col-md-12">
@@ -127,9 +127,9 @@
                                                             <select class="form-control" id="position" name="position_id" data-choices data-choices-search-true required>
                                                                 <option value="">Select Position</option>
                                                                 @foreach ($positions as $position)
-                                                                    <option value="{{ $position->id }}" 
+                                                                    <option value="{{ $position->id }}"
                                                                     {{ ($vacancy && $vacancy->position_id == $position->id) ? 'selected' : '' }}>
-                                                                    {{ $position->name }} 
+                                                                    {{ $position->name }}
                                                                     <span class="text-{{ optional($position->brand)->color ?: 'danger' }}">
                                                                         ({{ optional($position->brand)->name ?: 'N/A' }})
                                                                     </span>
@@ -146,9 +146,9 @@
                                                                     Please select a position
                                                                 </div>
                                                             @endif
-                                                        </div>                                                       
-                                                    </div>   
-                                                    
+                                                        </div>
+                                                    </div>
+
                                                     <div class="col-md-12">
                                                         <div class="mb-3">
                                                             <label for="openPositions" class="form-label">
@@ -162,7 +162,7 @@
                                                     </div>
                                                 </div>
                                             </div>
-                            
+
                                             <div class="d-flex align-items-start gap-3 mt-4">
                                                 <button type="button"
                                                     class="btn btn-secondary btn-label right ms-auto nexttab nexttab"
@@ -173,11 +173,11 @@
                                             </div>
                                         </div>
                                         <!-- end tab pane -->
-                            
+
                                         <!-------------------------------------------------------------------------------------
                                             SAP Numbers
                                         -------------------------------------------------------------------------------------->
-                            
+
                                         <div class="tab-pane fade" id="v-pills-sap-numbers" role="tabpanel"
                                             aria-labelledby="v-pills-sap-numbers-tab">
                                             <div>
@@ -186,7 +186,7 @@
                                                     Enter the SAP number associated with this job position.
                                                 </p>
                                             </div>
-                            
+
                                             <div>
                                                 <div id="sapNumbersContainer">
                                                     @if ($vacancy && $vacancy->sapNumbers->count() > 0)
@@ -212,7 +212,7 @@
                                                     @endif
                                                 </div>
                                             </div>
-                            
+
                                             <div class="d-flex align-items-start gap-3 mt-4">
                                                 <button type="button" class="btn btn-light btn-label previestab"
                                                     data-previous="v-pills-position-tab">
@@ -228,11 +228,11 @@
                                             </div>
                                         </div>
                                         <!-- end tab pane -->
-                            
+
                                         <!-------------------------------------------------------------------------------------
                                             Store
                                         -------------------------------------------------------------------------------------->
-                            
+
                                         <div class="tab-pane fade" id="v-pills-store" role="tabpanel"
                                             aria-labelledby="v-pills-store-tab">
                                             <div>
@@ -241,7 +241,7 @@
                                                     Choose the store that you are creating this vacancy for.
                                                 </p>
                                             </div>
-                            
+
                                             <div>
                                                 <div class="row gy-3">
                                                     <div class="col-md-12">
@@ -250,12 +250,12 @@
                                                                 <option value="">Select Store</option>
                                                                 @foreach ($stores as $store)
                                                                     <option value="{{$store->id}}"
-                                                                            {{ 
-                                                                                ($vacancy && $vacancy->store_id == $store->id) 
+                                                                            {{
+                                                                                ($vacancy && $vacancy->store_id == $store->id)
                                                                                 ? 'selected'
                                                                                 : ((!$vacancy && $user && $user->store_id == $store->id) ? 'selected' : '')
                                                                             }}
-                                                                            {{ 
+                                                                            {{
                                                                                 ($user && $user->store_id == $store->id) ? '' : 'disabled'
                                                                             }}>
                                                                         {{ $store->brand->name }} ({{ $store->name }})
@@ -263,11 +263,11 @@
                                                                 @endforeach
                                                             </select>
                                                             <div class="invalid-feedback">Please select a store</div>
-                                                        </div>                                                        
-                                                    </div>                                                    
+                                                        </div>
+                                                    </div>
                                                 </div>
                                             </div>
-                            
+
                                             <div class="d-flex align-items-start gap-3 mt-4">
                                                 <button type="button" class="btn btn-light btn-label previestab"
                                                     data-previous="v-pills-sap-numbers-tab">
@@ -283,11 +283,11 @@
                                             </div>
                                         </div>
                                         <!-- end tab pane -->
-                            
+
                                         <!-------------------------------------------------------------------------------------
                                             Type
                                         -------------------------------------------------------------------------------------->
-                            
+
                                         <div class="tab-pane fade" id="v-pills-type" role="tabpanel"
                                             aria-labelledby="v-pills-type-tab">
                                             <div>
@@ -296,13 +296,13 @@
                                                     Choose the job type that best matches the vacancy you're looking for.
                                                 </p>
                                             </div>
-                            
+
                                             <div>
                                                 <div class="row g-3">
                                                     @foreach ($types as $type)
                                                         <div class="col-xl-3 col-md-6 d-flex align-items-stretch">
                                                             <div class="form-check card-radio h-100 w-100">
-                                                                <div class="card card-animate card-height-100 shadow-lg d-flex flex-column">                                                                
+                                                                <div class="card card-animate card-height-100 shadow-lg d-flex flex-column">
                                                                     <input id="type-{{ $type->id }}" name="type_id" type="radio" class="form-check-input" value="{{ $type->id }}" {{ ($vacancy && $vacancy->type_id == $type->id) ? 'checked' : ($loop->first ? 'checked' : '') }} required />
                                                                     <label class="form-check-label d-flex flex-column h-100" for="type-{{ $type->id }}" style="white-space: normal;">
                                                                         <div class="card-body text-center d-flex flex-column justify-content-between">
@@ -319,15 +319,15 @@
                                                                                     {{ $type->name }}
                                                                                 </h6>
                                                                             </a>
-                                                                        </div>                                                                        
+                                                                        </div>
                                                                     </label>
                                                                 </div>
                                                             </div>
                                                         </div>
-                                                    @endforeach                                             
+                                                    @endforeach
                                                 </div>
                                             </div>
-                            
+
                                             <div class="d-flex align-items-start gap-3 mt-4">
                                                 <button type="button" class="btn btn-light btn-label previestab"
                                                     data-previous="{{ $user->role_id == 6 ? 'v-pills-sap-numbers-tab' : 'v-pills-store-tab' }}">
@@ -343,11 +343,11 @@
                                             </div>
                                         </div>
                                         <!-- end tab pane -->
-                            
+
                                         <!-------------------------------------------------------------------------------------
                                             Advertisement
                                         -------------------------------------------------------------------------------------->
-                            
+
                                         <!--
                                         <div class="tab-pane fade" id="v-pills-advertisement" role="tabpanel"
                                             aria-labelledby="v-pills-advertisement-tab">
@@ -357,12 +357,12 @@
                                                     Choose to whom you would like to advertisement this job.
                                                 </p>
                                             </div>
-                            
+
                                             <div>
                                                 <div class="row g-3">
                                                     <div class="col-xl-3 col-md-6 d-flex align-items-stretch">
                                                         <div class="form-check card-radio h-100 w-100">
-                                                            <div class="card card-animate card-height-100 shadow-lg d-flex flex-column">                                                                
+                                                            <div class="card card-animate card-height-100 shadow-lg d-flex flex-column">
                                                                 <input id="advertisement-1" name="advertisement" type="radio" class="form-check-input" value="Any" {{ (empty($vacancy) || !$vacancy->advertisement || $vacancy->advertisement == 'Any') ? 'checked' : '' }} required />
                                                                 <label class="form-check-label d-flex flex-column h-100" for="advertisement-1" style="white-space: normal;">
                                                                     <div class="card-body text-center d-flex flex-column justify-content-between">
@@ -379,15 +379,15 @@
                                                                                 Any Applicants
                                                                             </h6>
                                                                         </a>
-                                                                    </div>                                                                        
+                                                                    </div>
                                                                 </label>
                                                             </div>
                                                         </div>
                                                     </div>
-                                                    
+
                                                     <div class="col-xl-3 col-md-6 d-flex align-items-stretch">
                                                         <div class="form-check card-radio h-100 w-100">
-                                                            <div class="card card-animate card-height-100 shadow-lg d-flex flex-column">                                                                
+                                                            <div class="card card-animate card-height-100 shadow-lg d-flex flex-column">
                                                                 <input id="advertisement-2" name="advertisement" type="radio" class="form-check-input" value="External" {{ ($vacancy && $vacancy->advertisement == 'External') ? 'checked' : '' }} required />
                                                                 <label class="form-check-label d-flex flex-column h-100" for="advertisement-2" style="white-space: normal;">
                                                                     <div class="card-body text-center d-flex flex-column justify-content-between">
@@ -404,15 +404,15 @@
                                                                                 External Applicants
                                                                             </h6>
                                                                         </a>
-                                                                    </div>                                                                        
+                                                                    </div>
                                                                 </label>
                                                             </div>
                                                         </div>
                                                     </div>
-                            
+
                                                     <div class="col-xl-3 col-md-6 d-flex align-items-stretch">
                                                         <div class="form-check card-radio h-100 w-100">
-                                                            <div class="card card-animate card-height-100 shadow-lg d-flex flex-column">                                                                
+                                                            <div class="card card-animate card-height-100 shadow-lg d-flex flex-column">
                                                                 <input id="advertisement-3" name="advertisement" type="radio" class="form-check-input" value="Internal" {{ ($vacancy && $vacancy->advertisement == 'Internal') ? 'checked' : '' }} required />
                                                                 <label class="form-check-label d-flex flex-column h-100" for="advertisement-3" style="white-space: normal;">
                                                                     <div class="card-body text-center d-flex flex-column justify-content-between">
@@ -429,14 +429,14 @@
                                                                                 Internal Applicants
                                                                             </h6>
                                                                         </a>
-                                                                    </div>                                                                        
+                                                                    </div>
                                                                 </label>
                                                             </div>
                                                         </div>
                                                     </div>
                                                 </div>
                                             </div>
-                            
+
                                             <div class="d-flex align-items-start gap-3 mt-4">
                                                 <button type="button" class="btn btn-light btn-label previestab"
                                                     data-previous="v-pills-type-tab">
@@ -453,11 +453,11 @@
                                         </div>
                                         -->
                                         <!-- end tab pane -->
-                            
+
                                         <!-------------------------------------------------------------------------------------
                                             Finish
                                         -------------------------------------------------------------------------------------->
-                            
+
                                         <div class="tab-pane fade d-flex align-items-center justify-content-center flex-column" id="v-pills-finish" role="tabpanel" aria-labelledby="v-pills-finish-tab">
                                             @if ($vacancy)
                                                 <!-- Update -->
@@ -471,20 +471,20 @@
                                                     </p>
                                                     @if ($user->role_id == 1)
                                                         <button type="button" id="editBtn" class="btn btn-light btn-label waves-effect waves-light rounded-pill" data-previous="v-pills-position-tab">
-                                                            <i class="ri-edit-box-line label-icon align-middle rounded-pill fs-16 me-2"></i> 
+                                                            <i class="ri-edit-box-line label-icon align-middle rounded-pill fs-16 me-2"></i>
                                                             Edit
                                                         </button>
                                                     @endif
                                                     <button type="submit" id="updateBtn" class="btn btn-secondary btn-label waves-effect waves-light rounded-pill">
-                                                        <i class="ri-check-double-line label-icon align-middle rounded-pill fs-16 me-2"></i> 
+                                                        <i class="ri-check-double-line label-icon align-middle rounded-pill fs-16 me-2"></i>
                                                         Yes, Update !
                                                     </button>
                                                     <a type="button" href="{{ route('job-overview.index', ['id' => Crypt::encryptString($vacancy->id)]) }}" id="view-vacancy" class="btn btn-primary btn-label waves-effect waves-light rounded-pill">
-                                                        <i class="ri-organization-chart label-icon align-middle rounded-pill fs-16 me-2"></i> 
+                                                        <i class="ri-organization-chart label-icon align-middle rounded-pill fs-16 me-2"></i>
                                                         View Vacancy
                                                     </a>
                                                 </div>
-                            
+
                                                 <!-- Loading -->
                                                 <div class="text-center pt-4 pb-2 mt-4 d-none" id="loading">
                                                     <div class="spinner-border text-success mb-4" role="status">
@@ -502,22 +502,22 @@
                                                         After creating the vacancy, you can proceed to create your shortlist.
                                                     </p>
                                                     <button type="button" id="cancelBtn" class="btn btn-light btn-label waves-effect waves-light rounded-pill" data-previous="v-pills-position-tab">
-                                                        <i class="ri-close-circle-line label-icon align-middle rounded-pill fs-16 me-2"></i> 
+                                                        <i class="ri-close-circle-line label-icon align-middle rounded-pill fs-16 me-2"></i>
                                                         No, Cancel
                                                     </button>
                                                     <button type="submit" id="submitBtn" class="btn btn-secondary btn-label waves-effect waves-light rounded-pill">
-                                                        <i class="ri-check-double-line label-icon align-middle rounded-pill fs-16 me-2"></i> 
+                                                        <i class="ri-check-double-line label-icon align-middle rounded-pill fs-16 me-2"></i>
                                                         Yes, Create !
                                                     </button>
-                                                </div>                                            
-                            
+                                                </div>
+
                                                 <!-- Loading -->
                                                 <div class="text-center pt-4 pb-2 d-none" id="loading">
                                                     <div class="spinner-border text-success mb-4" role="status">
                                                         <span class="sr-only">Loading...</span>
                                                     </div>
                                                 </div>
-                            
+
                                                 <!-- Complete -->
                                                 <div class="text-center pt-4 pb-2 d-none" id="complete">
                                                     <div class="mb-4">
@@ -529,17 +529,17 @@
                                                     </p>
                                                     @if ($user->role_id == 1)
                                                         <button type="button" id="editBtn" class="btn btn-light btn-label waves-effect waves-light rounded-pill" data-previous="v-pills-position-tab">
-                                                            <i class="ri-edit-box-line label-icon align-middle rounded-pill fs-16 me-2"></i> 
+                                                            <i class="ri-edit-box-line label-icon align-middle rounded-pill fs-16 me-2"></i>
                                                             Edit
                                                         </button>
                                                     @endif
                                                     <a type="button" id="view-vacancy" class="btn btn-primary btn-label waves-effect waves-light rounded-pill">
-                                                        <i class="ri-organization-chart label-icon align-middle rounded-pill fs-16 me-2"></i> 
+                                                        <i class="ri-organization-chart label-icon align-middle rounded-pill fs-16 me-2"></i>
                                                         View Vacancy
                                                     </a>
                                                 </div>
                                             @endif
-                            
+
                                             <!-- Danger Alert -->
                                             <div class="alert alert-danger alert-dismissible fade text-center mt-4" role="alert" id="requiredAlert">
                                                 <strong>Some fields are missing!</strong> Please make sure that all the required fields are filled out
@@ -547,12 +547,12 @@
                                             </div>
                                         </div>
                                         <!-- end tab pane -->
-                            
+
                                     </div>
                                     <!-- end tab content -->
                                 </div>
                             </div>
-                            <!-- end col -->                            
+                            <!-- end col -->
                         </div>
                         <!-- end row -->
                     </form>

--- a/resources/views/manager/vacancy.blade.php
+++ b/resources/views/manager/vacancy.blade.php
@@ -256,7 +256,7 @@
                                                                                 : ((!$vacancy && $user && $user->store_id == $store->id) ? 'selected' : '')
                                                                             }}
                                                                             {{
-                                                                                ($user && $user->store_id == $store->id) ? '' : 'disabled'
+                                                                                ($user && $user->role_id == 6 && $user->store_id != $store->id) ? 'disabled' : ''
                                                                             }}>
                                                                         {{ $store->brand->name }} ({{ $store->name }})
                                                                     </option>

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,7 +24,7 @@ Auth::routes(['verify' => true]);
 |--------------------------------------------------------------------------
 */
 
-Route::prefix('admin')->middleware(['auth', 'verified', 'role:1,2,3,4,5', 'user.activity'])->group(function () {
+Route::prefix('admin')->middleware(['auth', 'verified', 'role:1,2', 'user.activity'])->group(function () {
     //Home
 
     Route::get('/home', [App\Http\Controllers\AdminController::class, 'index'])->name('admin.home');
@@ -558,7 +558,7 @@ Route::prefix('dpp')->middleware(['auth', 'verified', 'role:5', 'user.activity']
 |--------------------------------------------------------------------------
 */
 
-Route::prefix('manager')->middleware(['auth', 'verified', 'role:1,2,3,4,5,6', 'user.activity'])->group(function () {
+Route::prefix('manager')->middleware(['auth', 'verified', 'role:1,2,3,4,6', 'user.activity'])->group(function () {
     //Home
 
     Route::get('/home', [App\Http\Controllers\ManagerController::class, 'index'])->name('manager.home');
@@ -676,7 +676,7 @@ Route::middleware(['auth', 'verified', 'user.activity'])->group(function () {
 
     Route::post('/files/add', [App\Http\Controllers\JobOverviewController::class, 'store'])->name('file.store');
 
-    Route::delete('/files/delete/{id}', [App\Http\Controllers\JobOverviewController::class, 'destroy'])->name('file.destroy');    
+    Route::delete('/files/delete/{id}', [App\Http\Controllers\JobOverviewController::class, 'destroy'])->name('file.destroy');
 
     //Messages
 
@@ -712,7 +712,7 @@ Route::middleware(['auth', 'verified', 'user.activity'])->group(function () {
     //My Profile Settings
 
     Route::get('/profile-settings', [App\Http\Controllers\ProfileSettingsController::class, 'index'])->name('profile-settings.index');
-    
+
     Route::post('/update-profile', [App\Http\Controllers\ProfileSettingsController::class, 'update'])->name('profile-settings.update');
 
     Route::post('/update-password', [App\Http\Controllers\ProfileSettingsController::class, 'updatePassword'])->name('profile-settings.updatePassword');


### PR DESCRIPTION
We need to update the VacancyController to handle permissions and selections for the RPP, DTDP, and DPP roles. The following changes are required:

Position Selection Logic:

If the user's role is RPP (role_id = 3), they should be able to select positions from all brands of all stores where region_id = $user->region_id.

If the user's role is DTDP (role_id = 4), they should be able to select positions from all brands of all stores where division_id = $user->division_id.

For DPP (role_id = 6), they should only be able to view dashboards, no access to vacancy creation or editing.

Current Code:

if (in_array($user->role_id, [1, 2])) {
    // If role_id is 1 or 2, get all positions where id > 1
    $positions = Position::where('id', '>', 1)->get();
} elseif ($user->role_id > 2 && $user->role_id < 7) {
    // If role_id is between 3 and 6, check if the user has a brand_id
    if ($user->brand_id) {
        $positions = Position::where('brand_id', $user->brand_id)->get();
    }
} elseif (in_array($user->role_id, [7, 8]) || !$user->brand_id) {
    // If role_id is 7 or 8, or user does not have a brand_id, return empty collection
    $positions = collect();
}

Required Update:

RPP (role_id = 3): Fetch positions from all stores where region_id = $user->region_id.

DTDP (role_id = 4): Fetch positions from all stores where division_id = $user->division_id.

Store Selection Logic:

For RPP (role_id = 3), the stores should be limited to those where region_id = $user->region_id.

For DTDP (role_id = 4), the stores should be limited to those where division_id = $user->division_id.

For Managers, limit the store selection to id = $user->store_id.

Current Code:

$stores = Store::with(['brand', 'town'])->get();

Required Update:

Modify the Store query to filter based on the user’s region_id, division_id, or store_id based on their role.

Validation Rules for Vacancy Creation: In the store and update functions, we need additional validation for the store_id field based on the user’s role:

For Manager (role_id = 6), ensure that store_id is the same as Auth::user()->store_id. If not, throw an error: "You are not authorized to create a vacancy at the selected store."

For RPP (role_id = 3), validate that the region_id of the selected store matches Auth::user()->region_id.

For DTDP (role_id = 4), validate that the division_id of the selected store matches Auth::user()->division_id.

Current Code:

public function store(Request $request)
{
    $request->validate([
        'position_id' => 'required|integer|exists:positions,id',
        'open_positions' => 'required|integer|min:1|max:10',
        'sap_numbers' => 'required|array',
        'sap_numbers.*' => ['digits:8', function ($attribute, $value, $fail) {
            if (DB::table('sap_numbers')->where('sap_number', $value)->exists()) {
                $fail('The SAP number ' . $value . ' has already been taken.');
            }
        }],
        'store_id' => 'required|integer|exists:stores,id',
        'type_id' => 'required|integer|exists:types,id',
    ]);
}

Required Update:

Add custom validation logic based on Auth::user()->role_id:

If role_id = 6 (Manager), ensure store_id = $user->store_id.

If role_id = 3 (RPP), ensure region_id = $user->region_id.

If role_id = 4 (DTDP), ensure division_id = $user->division_id.

Permissions:

Ensure that RPP and DTDP roles have the same permissions as a Manager, except for the store_id and position_id validation logic.

DPP should only be able to view dashboards, not create or edit vacancies.

Acceptance Criteria:

RPP and DTDP roles should be able to create and update vacancies within their region_id or division_id.

DPP role should be restricted to viewing dashboards only.

Validation rules should ensure that users cannot create vacancies outside their allowed stores.

Permissions for RPP, DTDP, and Managers should be aligned.