### PR TITLE
SS-191 | Handle Reused SAP Numbers in Vacancy Controller

### DIFF
--- a/database/migrations/2025_02_19_111238_add_auto_deleted_column_to_vacancies_table.php
+++ b/database/migrations/2025_02_19_111238_add_auto_deleted_column_to_vacancies_table.php
@@ -4,16 +4,17 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      */
     public function up()
     {
-        Schema::table('vacancies', function (Blueprint $table) {
-            $table->enum('auto_deleted', ['Yes', 'No'])->default('No')->nullable()->after('deleted');
-        });
+        if (!Schema::hasColumn('vacancies', 'auto_deleted')) {
+            Schema::table('vacancies', function (Blueprint $table) {
+                $table->enum('auto_deleted', ['Yes', 'No'])->default('No')->nullable()->after('deleted');
+            });
+        }
     }
 
     /**
@@ -21,8 +22,10 @@ return new class extends Migration
      */
     public function down()
     {
-        Schema::table('vacancies', function (Blueprint $table) {
-            $table->dropColumn('auto_deleted');
-        });
+        if (Schema::hasColumn('vacancies', 'auto_deleted')) {
+            Schema::table('vacancies', function (Blueprint $table) {
+                $table->dropColumn('auto_deleted');
+            });
+        }
     }
 };

--- a/database/migrations/2025_02_20_091201_add_appointments_to_applicants_table.php
+++ b/database/migrations/2025_02_20_091201_add_appointments_to_applicants_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        if (!Schema::hasColumn('applicants', 'appointments')) {
+            Schema::table('applicants', function (Blueprint $table) {
+                $table->json('appointments')->nullable()->after('appointed_id');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        if (Schema::hasColumn('applicants', 'appointments')) {
+            Schema::table('applicants', function (Blueprint $table) {
+                $table->dropColumn('appointments');
+            });
+        }
+    }
+};


### PR DESCRIPTION
Enhance the vacancy controller to properly handle reused SAP numbers, ensuring that previous vacancies are updated correctly based on their appointment status.